### PR TITLE
Update nala and pwsh roles to fix keyring paths

### DIFF
--- a/roles/nala/tasks/ubuntu.yml
+++ b/roles/nala/tasks/ubuntu.yml
@@ -21,7 +21,7 @@
     - name: "Nala | Add nala repo gpg key"
       apt_key:
         url: "https://deb.volian.org/volian/scar.key"
-        keyring: volian-archive-scar-unstable.gpg
+        keyring: /etc/apt/trusted.gpg.d/volian-archive-scar-unstable.gpg
         state: present
 
     - name: "Nala | Add nala repository source"

--- a/roles/pwsh/tasks/ubuntu.yml
+++ b/roles/pwsh/tasks/ubuntu.yml
@@ -2,6 +2,7 @@
 - name: "PowerShell | Download and Add Powershell Key to Apt-Get Keyring"
   ansible.builtin.apt_key:
     url: "https://packages.microsoft.com/keys/microsoft.asc"
+    keyring: "/etc/apt/trusted.gpg.d/microsoft.gpg"
     state: present
   become: true
 
@@ -16,5 +17,5 @@
     name:
       - powershell
     update_cache: true
-    state: latest
+    state: present
   become: true


### PR DESCRIPTION
- Update nala role to use correct keyring path for nala repo gpg key
- Update pwsh role to use correct keyring path for powershell key in apt-get
- Ensure both roles are in present state
- Fixes issue with keyring paths causing errors during package installation.
