### PR TITLE
Fix(bash): Beginning slash causes permission issues. Closes #103

### DIFF
--- a/roles/bash/tasks/ubuntu.yml
+++ b/roles/bash/tasks/ubuntu.yml
@@ -18,7 +18,7 @@
     - name: "Bash | Download oh-my-bash Install Script"
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh
-        dest: /{{ ansible_user_dir }}/oh-my-bash.install.sh
+        dest: "{{ ansible_user_dir }}/oh-my-bash.install.sh"
         force: true
         mode: 755
       notify:
@@ -26,7 +26,7 @@
 
     - name: "Bash | Run the install script"
       ansible.builtin.script:
-        cmd: /{{ ansible_user_dir }}/oh-my-bash.install.sh
+        cmd: "{{ ansible_user_dir }}/oh-my-bash.install.sh"
 
 - name: "Bash | Copy .bashrc"
   ansible.builtin.copy:


### PR DESCRIPTION
This pull request includes a minor change to the `roles/bash/tasks/ubuntu.yml` file. The change modifies the `dest` and `cmd` parameters in the "Bash | Download oh-my-bash Install Script" and "Bash | Run the install script" tasks respectively. The modification replaces the hard-coded path with a variable, which allows for more flexibility and reduces potential errors related to hard-coded paths. Specifically, the `ansible_user_dir` variable has been enclosed in quotes to ensure it is interpreted as a string.